### PR TITLE
Update Google Analytics tracking ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,13 +15,13 @@
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/zenburn.min.css">
 
 	<!-- Global site tag (gtag.js) - Google Analytics -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-126276861-1"></script>
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-80639740-2"></script>
 	<script>
 	  window.dataLayer = window.dataLayer || [];
 	  function gtag(){dataLayer.push(arguments);}
 	  gtag('js', new Date());
 
-	  gtag('config', 'UA-126276861-1');
+	  gtag('config', 'UA-80639740-2');
 	</script>
 
     <style>

--- a/index.html
+++ b/index.html
@@ -14,15 +14,15 @@
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/zenburn.min.css">
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-80639740-1"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-126276861-1"></script>
+	<script>
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
 
-        gtag('config', 'UA-80639740-1');
-    </script>
+	  gtag('config', 'UA-126276861-1');
+	</script>
 
     <style>
         .customnav {


### PR DESCRIPTION
Created dedicated account for GA so we can get better insight into traffic.

Use of a new ID for GA tracking. It is recommended setup instead of trying to use the original ID for dbatools.io with a child domain site.