### PR TITLE
GitHub Action to update assets based on dbatools release

### DIFF
--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -1,0 +1,22 @@
+name: update-assets
+on:
+  workflow_dispatch:
+
+jobs:
+  updatehelpindex:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout'
+      uses: 'actions/checkout@v2.3.4'
+
+    - name: 'Pull help index file'
+      working-directory: assets
+      run: curl -O https://raw.githubusercontent.com/sqlcollaborative/docs/master/bin/dbatools-index.json
+
+    - name: commit if file changed
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: updating help index file
+
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -20,3 +20,30 @@ jobs:
 
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bumpversion:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout'
+      uses: 'actions/checkout@v2.3.4'
+
+    - name: 'Pull module manifest to get version'
+      working-directory: assets
+      shell: pwsh
+      run: |
+        curl -O https://raw.githubusercontent.com/sqlcollaborative/dbatools/master/dbatools.psd1
+        $modData = Import-PowerShellDataFile dbatools.psd1
+        $ext = Get-Content .\external.json | ConvertFrom-Json
+        if ($ext.Version -ne $modData.ModuleVersion) {
+          $ext.Version = $modData.Module Version
+          $ext | ConvertTo-Json | Out-File ./external.json
+        }
+        Remove-Item ./dbatools.psd1 -Force
+
+    - name: commit if file changed
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: bumping doc version
+
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -11,7 +11,7 @@ jobs:
 
     - name: 'Pull help index file'
       working-directory: assets
-      run: curl -O https://raw.githubusercontent.com/sqlcollaborative/docs/master/bin/dbatools-index.json
+      run: curl -O https://raw.githubusercontent.com/sqlcollaborative/dbatools/master/bin/dbatools-index.json
 
     - name: commit if file changed
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -11,15 +11,17 @@ jobs:
 
     - name: 'Pull help index file'
       working-directory: assets
-      run: curl -O https://raw.githubusercontent.com/sqlcollaborative/dbatools/master/bin/dbatools-index.json
+      run: |
+        curl -O https://raw.githubusercontent.com/sqlcollaborative/dbatools/master/bin/dbatools-index.json
+        git status
 
-    - name: commit if file changed
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: updating help index file
+    # - name: commit if file changed
+    #   uses: stefanzweifel/git-auto-commit-action@v4
+    #   with:
+    #     commit_message: updating help index file
 
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   bumpversion:
     runs-on: ubuntu-latest
@@ -27,23 +29,25 @@ jobs:
     - name: 'Checkout'
       uses: 'actions/checkout@v2.3.4'
 
-    - name: 'Pull module manifest to get version'
+    - name: 'Bump version based on manifest'
       working-directory: assets
       shell: pwsh
       run: |
         curl -O https://raw.githubusercontent.com/sqlcollaborative/dbatools/master/dbatools.psd1
         $modData = Import-PowerShellDataFile dbatools.psd1
         $ext = Get-Content .\external.json | ConvertFrom-Json
+        echo "Module version: $($modData.ModuleVersion)"
+        echo "External version: $($ext.Version)"
         if ($ext.Version -ne $modData.ModuleVersion) {
           $ext.Version = $modData.Module Version
           $ext | ConvertTo-Json | Out-File ./external.json
         }
         Remove-Item ./dbatools.psd1 -Force
 
-    - name: commit if file changed
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: bumping doc version
+    # - name: commit if file changed
+    #   uses: stefanzweifel/git-auto-commit-action@v4
+    #   with:
+    #     commit_message: bumping doc version
 
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #43 to update asset files based on releases being pushed to the master branch.

@potatoqualitee the action right now should only run by manually triggering it (if I read docs right). Once we run it a few times then we can update to have it run on a schedule.